### PR TITLE
Updated pt-PT Translation + Added Missing Strings

### DIFF
--- a/languages/pt_PT.js
+++ b/languages/pt_PT.js
@@ -11,7 +11,7 @@ const pt_PT = {
     fileInfo: "linhas",
     
     // Translation temperature
-    temperatureTitle: "Temperatura da Tradução",
+    temperatureTitle: "Nível da Tradução",
     temperatureAccurate: "Precisa",
     temperatureBalanced: "Equilibrada",
     temperatureCreative: "Criativa",

--- a/languages/pt_PT.js
+++ b/languages/pt_PT.js
@@ -4,38 +4,38 @@ const pt_PT = {
     appTitle: "Tradutor de Legendas SRT",
     
     // File upload
-    fileUploadTitle: "Carregar Arquivo de Legendas",
-    fileInputLabel: "Escolher Arquivo",
-    browseButton: "Navegar...",
-    noFileSelected: "Nenhum arquivo selecionado",
+    fileUploadTitle: "Carregar Ficheiro de Legendas",
+    fileInputLabel: "Escolher Ficheiro",
+    browseButton: "Procurar...",
+    noFileSelected: "Nenhum ficheiro selecionado",
     fileInfo: "linhas",
     
     // Translation temperature
-    temperatureTitle: "Temperatura de Tradução",
-    temperatureAccurate: "Preciso",
-    temperatureBalanced: "Equilibrado",
-    temperatureCreative: "Criativo",
+    temperatureTitle: "Temperatura da Tradução",
+    temperatureAccurate: "Precisa",
+    temperatureBalanced: "Equilibrada",
+    temperatureCreative: "Criativa",
     
     // Translation mode and API key
     languageTitle: "Tradução",
-    translationModeTitle: "Modo de tradução",
-    apiKeyLabel: "Chave API",
+    translationModeTitle: "Modo de Tradução",
+    apiKeyLabel: "Chave da API",
     showApiKeyButton: "Mostrar",
     sourceLanguage: "Idioma de Origem",
     targetLanguage: "Idioma de Destino",
     
-    // OpenRouter modellválasztó
+    // OpenRouter model selector
     openrouterModelLabel: "Seleção de modelo OpenRouter:",
-    selectModelPlaceholder: "Selecione um modelo...",
+    selectModelPlaceholder: "Selecionar um modelo...",
     
     // Buttons
     startTranslation: "Iniciar Tradução",
     continueTranslation: "Continuar Tradução",
     stopTranslation: "Parar Tradução",
     resetTranslation: "Reiniciar",
-    saveTranslation: "Salvar Tradução",
-    saveWorkFile: "Salvar Arquivo de Trabalho",
-    saveSourceBlock: "Salvar Bloco de Origem",
+    saveTranslation: "Guardar Tradução",
+    saveWorkFile: "Guardar Ficheiro de Trabalho",
+    saveSourceBlock: "Guardar Bloco de Origem",
     
     // Table
     originalSubtitle: "Legenda Original",
@@ -48,51 +48,65 @@ const pt_PT = {
     translationComplete: "Tradução Concluída",
     translationStopped: "Tradução Interrompida",
     translationReset: "Tradução Reiniciada",
-    translationSaved: "Tradução Salva",
-    workFileSaved: "Arquivo de Trabalho Salvo",
+    translationSaved: "Tradução Guardada",
+    workFileSaved: "Ficheiro de Trabalho Guardado",
     
     // Success messages
     successTranslation: "Tradução concluída com sucesso!",
     translationCompleted: "Tradução concluída com sucesso!",
-    successLoadWorkFile: "Arquivo de trabalho carregado com sucesso! Você pode continuar a tradução.",
-    successSaveWorkFile: "Arquivo de trabalho salvo com sucesso!",
+    successLoadWorkFile: "Ficheiro de trabalho carregado com sucesso! Podes continuar a tradução.",
+    successSaveWorkFile: "Ficheiro de trabalho guardado com sucesso!",
+    successWorkFile: "Ficheiro de trabalho guardado com sucesso!",
+    successSourceBlock: "Bloco de origem guardado com sucesso!",
     
     // Error messages
-    errorFileLoad: "Erro ao carregar o arquivo",
-    errorTranslation: "Ocorreu um erro durante a tradução!",
-    errorSave: "Erro ao salvar o arquivo",
-    errorNoFile: "Por favor, selecione um arquivo!",
-    errorTranslationRunning: "Por favor, pare a tradução antes de carregar um novo arquivo!",
-    errorInvalidFile: "Apenas arquivos .srt, .wrk ou .mmm podem ser carregados!",
-    errorNoSubtitles: "O arquivo não contém legendas válidas!",
-    errorNoSrtFirst: "Por favor, carregue um arquivo .srt primeiro antes de carregar um arquivo .mmm!",
-    errorNoValidText: "O arquivo não contém textos válidos ou os números de linha não correspondem às legendas carregadas!",
-    errorNoTranslation: "Nada para salvar! Por favor, traduza as legendas primeiro.",
-    errorNoSubtitleToSave: "Nenhuma legenda carregada para salvar!",
-    errorApiNotAvailable: "A API do LM Studio não está disponível. Verifique se o LM Studio está sendo executado em segundo plano.",
+    errorFileLoad: "Erro ao carregar o ficheiro",
+    errorTranslation: "Erro durante a tradução",
+    errorSave: "Erro ao guardar o ficheiro",
+    errorSaveTranslation: "Erro ao guardar a tradução",
+    errorSaveSrt: "Erro ao guardar o ficheiro SRT",
+    errorSaveSourceBlock: "Erro ao guardar o bloco de origem",
+    errorNoFile: "Seleciona um ficheiro!",
+    errorTranslationRunning: "Para a tradução antes de carregar um novo ficheiro!",
+    errorInvalidFile: "Apenas ficheiros .srt, .wrk ou .mmm podem ser carregados!",
+    errorLoadLanguage: "Erro ao carregar o ficheiro de idioma",
+    errorNoSrtFirst: "Carrega primeiro um ficheiro .srt antes de carregar um ficheiro .mmm!",
+    errorNoValidText: "O ficheiro não contém texto válido ou a numeração das linhas não corresponde às legendas carregadas!",
+    errorNoSubtitles: "Nenhuma legenda carregada",
+    errorNoSubtitleToSave: "Nenhuma legenda carregada para guardar!",
+    errorNoTranslation: "Nenhuma tradução disponível",
+    errorNoSourceLanguage: "Seleciona a língua de origem",
+    errorNoTargetLanguage: "Seleciona a língua de destino",
+    errorApiKey: "A chave da API é obrigatória para este modo de tradução",
+    errorApiNotAvailable: "A API do LM Studio não está disponível. Verifica se o LM Studio está a correr em segundo plano.",
     errorRetranslation: "Ocorreu um erro durante a retradução!",
-    errorLoadWorkFile: "Ocorreu um erro ao carregar o arquivo de trabalho. Verifique o formato do arquivo!",
-    errorServerConnection: "Não foi possível conectar ao servidor LM Studio",
+    errorLoadWorkFile: "Ocorreu um erro ao carregar o ficheiro de trabalho. Verifica o formato do ficheiro!",
+    errorServerConnection: "Não foi possível ligar ao servidor do LM Studio",
+    errorFileSave: "Erro ao guardar o ficheiro!",
     
-    // Textos de animação de carregamento
-    loadingGeneral: "Carregando...",
-    loadingFileProcessing: "Processando arquivo...",
-    loadingTablePopulation: "Preenchendo tabela...",
-    loadingWorkFileProcessing: "Processando arquivo de trabalho...",
-    loadingMmmFileProcessing: "Processando arquivo MMM...",
-    loadingTranslation: "Traduzindo...",
-    loadingClickToClose: "Clique em qualquer lugar fora para fechar",
-    loadingBatchTranslation: "Tradução em lote em andamento...",
+    // API key management
+    toggleApiKeyVisibility: "Mostrar/Ocultar chave da API",
     
-    // Mensagens de erro do modo de tradução em lote
-    errorNumberingRetry: "Erro de numeração, tentando novamente ({0}/{1})...",
-    errorRateLimitExceeded: "Limite de taxa da API excedido, aguardando 10 segundos...",
-    errorTranslationRetry: "Erro de tradução, tentando novamente ({0}/{1})...",
-    errorTranslationFailed: "Tradução falhou após {0} tentativas, continuando...",
+    // Loading animation texts
+    loadingGeneral: "A carregar...",
+    loadingFileProcessing: "A processar o ficheiro...",
+    loadingTablePopulation: "A preencher a tabela...",
+    loadingWorkFileProcessing: "A processar o ficheiro de trabalho...",
+    loadingMmmFileProcessing: "A processar o ficheiro MMM...",
+    loadingTranslation: "A traduzir...",
+    loadingClickToClose: "Clica em qualquer parte para fechar",
+    loadingBatchTranslation: "Tradução em lote em curso...",
     
-    // Modo de tradução especial
-    batchModeLabel: "Modo de tradução especial de contexto amplo",
-    batchModeInfo: "Quando este recurso está ativado, o programa processa 30 linhas de texto de uma vez de maneira especial, permitindo uma tradução mais rápida com melhor compreensão e precisão"
+    // Batch translation mode error messages
+    errorNumberingRetry: "Erro de numeração, a tentar novamente ({0}/{1})...",
+    errorRateLimitExceeded: "Limite de pedidos da API excedido, a aguardar 10 segundos...",
+    errorTranslationRetry: "Erro de tradução, a tentar novamente ({0}/{1})...",
+    errorTranslationFailed: "A tradução falhou após {0} tentativas, a avançar...",
+    batchTranslationInProgress: "Tradução em curso: {0} {1}-{2}...",
+    
+    // Special translation mode
+    batchModeLabel: "Modo especial de tradução com contexto alargado",
+    batchModeInfo: "Quando esta opção está ativa, o programa processa 30 linhas de texto de cada vez, permitindo uma tradução mais rápida e com melhor compreensão e precisão."
 };
 
 // Export the language object


### PR DESCRIPTION
This PR updates the European Portuguese (pt-PT) translation file, which previously contained several Brazilian Portuguese strings. All entries were reviewed and corrected to proper pt-PT according to AO90.

Additionally, 6 missing strings have been added to keep the translation fully aligned with the current English source.

Changes included:

Replaced Brazilian Portuguese phrasing with correct pt-PT equivalents

Added missing translation keys

Normalised terminology for consistency across the UI

Ensured wording matches software context (imperative voice, concise UI style)